### PR TITLE
BR-27 - refactor EntityUtils

### DIFF
--- a/src/main/java/com/bobocode/svydovets/bibernate/action/SelectAction.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/action/SelectAction.java
@@ -4,19 +4,28 @@ import com.bobocode.svydovets.bibernate.action.executor.JdbcExecutor;
 import com.bobocode.svydovets.bibernate.action.key.EntityKey;
 import com.bobocode.svydovets.bibernate.action.mapper.ResultSetMapper;
 import com.bobocode.svydovets.bibernate.action.query.SqlQueryBuilder;
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.validation.annotation.required.processor.RequiredAnnotationValidatorProcessor;
+import com.bobocode.svydovets.bibernate.validation.annotation.required.processor.RequiredAnnotationValidatorProcessorImpl;
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 public class SelectAction implements Action {
     private final DataSource dataSource;
     private final SqlQueryBuilder sqlQueryBuilder;
+    private final RequiredAnnotationValidatorProcessor validatorProcessor;
+
+    public SelectAction(DataSource dataSource, SqlQueryBuilder sqlQueryBuilder) {
+        this.dataSource = dataSource;
+        this.sqlQueryBuilder = sqlQueryBuilder;
+        this.validatorProcessor = new RequiredAnnotationValidatorProcessorImpl();
+    }
 
     @Override
     public <T> T execute(EntityKey<T> key) {
+        validatorProcessor.validate(key.type(), Operation.SELECT);
         String selectByIdQuery = sqlQueryBuilder.createSelectByIdQuery(key.type());
         return processExecutingQuery(key, selectByIdQuery);
     }

--- a/src/main/java/com/bobocode/svydovets/bibernate/constant/ErrorMessage.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/constant/ErrorMessage.java
@@ -1,7 +1,7 @@
-package com.bobocode.svydovets.bibernate.util;
+package com.bobocode.svydovets.bibernate.constant;
 
-public final class Constants {
-    private Constants() {}
+public final class ErrorMessage {
+    private ErrorMessage() {}
 
     public static final String CLASS_HAS_NO_ENTITY_ANNOTATION =
             "Class '%s' has no @Entity annotation (every entity class must be annotated with '@Entity')";
@@ -9,4 +9,6 @@ public final class Constants {
             "Entity '%s' has no 'no-arg constructor' (every '@Entity' class must declare 'no-arg constructor')";
     public static final String CAN_NOT_CREATE_A_SNAPSHOT_OF_ENTITY =
             "Can not create a snapshot object for entity";
+    public static final String CLASS_HAS_NO_ID =
+            "Entity %s has no identifier (every '@Entity' class must declare or inherit at least one '@Id'";
 }

--- a/src/main/java/com/bobocode/svydovets/bibernate/constant/Operation.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/constant/Operation.java
@@ -1,0 +1,13 @@
+package com.bobocode.svydovets.bibernate.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Operation {
+    SELECT,
+    UPDATE,
+    INSERT,
+    DELETE
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/session/SessionImpl.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/session/SessionImpl.java
@@ -2,7 +2,6 @@ package com.bobocode.svydovets.bibernate.session;
 
 import com.bobocode.svydovets.bibernate.action.SelectAction;
 import com.bobocode.svydovets.bibernate.action.key.EntityKey;
-import com.bobocode.svydovets.bibernate.util.EntityUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,7 +15,6 @@ public class SessionImpl implements Session {
 
     @Override
     public <T> T find(Class<T> type, Object id) {
-        EntityUtils.validateEntity(type);
         EntityKey<T> entityKey = new EntityKey<>(type, id);
         return type.cast(persistenceContext.computeIfAbsent(entityKey, selectAction::execute));
     }

--- a/src/main/java/com/bobocode/svydovets/bibernate/util/EntityUtils.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/util/EntityUtils.java
@@ -1,7 +1,7 @@
 package com.bobocode.svydovets.bibernate.util;
 
-import static com.bobocode.svydovets.bibernate.util.Constants.CLASS_HAS_NO_ARG_CONSTRUCTOR;
-import static com.bobocode.svydovets.bibernate.util.Constants.CLASS_HAS_NO_ENTITY_ANNOTATION;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ARG_CONSTRUCTOR;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ENTITY_ANNOTATION;
 import static java.util.function.Predicate.not;
 
 import com.bobocode.svydovets.bibernate.annotation.Column;
@@ -17,21 +17,14 @@ import lombok.extern.slf4j.Slf4j;
 public class EntityUtils {
     private EntityUtils() {}
 
-    public static void validateEntity(Class<?> type) {
-        log.info("Validation {}", type.getName());
-        checkIsEntity(type);
-        //        todo: check that the class entity has at least one @Id
-        checkHasNoArgConstructor(type);
-    }
-
-    private static void checkIsEntity(Class<?> type) {
+    public static void checkIsEntity(Class<?> type) {
         if (!type.isAnnotationPresent(Entity.class)) {
             throw new EntityValidationException(
                     String.format(CLASS_HAS_NO_ENTITY_ANNOTATION, type.getName()));
         }
     }
 
-    private static void checkHasNoArgConstructor(Class<?> type) {
+    public static void checkHasNoArgConstructor(Class<?> type) {
         Arrays.stream(type.getConstructors())
                 .filter(constructor -> constructor.getParameterCount() == 0)
                 .findAny()
@@ -54,6 +47,16 @@ public class EntityUtils {
                 .toArray(Field[]::new);
     }
 
+    public static Field[] getUpdatableFields(Class<?> entityType) {
+        return Arrays.stream(entityType.getDeclaredFields())
+                .filter(EntityUtils::isUpdatableField)
+                .toArray(Field[]::new);
+    }
+
+    public static boolean isIdField(Field field) {
+        return field.isAnnotationPresent(Id.class);
+    }
+
     private static boolean isInsertableField(Field field) {
         return isInsertableNonId(field) || isNonColumnAnnotatedNonIdField(field);
     }
@@ -65,12 +68,6 @@ public class EntityUtils {
     private static boolean isInsertable(Field field) {
         return field.isAnnotationPresent(Column.class)
                 && field.getAnnotation(Column.class).insertable();
-    }
-
-    public static Field[] getUpdatableFields(Class<?> entityType) {
-        return Arrays.stream(entityType.getDeclaredFields())
-                .filter(EntityUtils::isUpdatableField)
-                .toArray(Field[]::new);
     }
 
     private static boolean isUpdatableField(Field field) {
@@ -87,9 +84,5 @@ public class EntityUtils {
 
     private static boolean isNonColumnAnnotatedNonIdField(Field field) {
         return !field.isAnnotationPresent(Column.class) && !isIdField(field);
-    }
-
-    private static boolean isIdField(Field field) {
-        return field.isAnnotationPresent(Id.class);
     }
 }

--- a/src/main/java/com/bobocode/svydovets/bibernate/util/ObjectCloneUtils.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/util/ObjectCloneUtils.java
@@ -1,6 +1,6 @@
 package com.bobocode.svydovets.bibernate.util;
 
-import static com.bobocode.svydovets.bibernate.util.Constants.CAN_NOT_CREATE_A_SNAPSHOT_OF_ENTITY;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CAN_NOT_CREATE_A_SNAPSHOT_OF_ENTITY;
 
 import com.bobocode.svydovets.bibernate.exception.BibernateException;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/Validator.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/Validator.java
@@ -1,0 +1,10 @@
+package com.bobocode.svydovets.bibernate.validation;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+
+public interface Validator {
+
+    void validate(Class<?> type);
+
+    boolean support(Operation operation);
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/AbstractRequiredValidator.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/AbstractRequiredValidator.java
@@ -1,0 +1,19 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.util.EntityUtils;
+import com.bobocode.svydovets.bibernate.validation.Validator;
+import java.util.Set;
+
+public abstract class AbstractRequiredValidator implements Validator {
+
+    protected static final Set<Operation> supportedOperations = Set.of(Operation.values());
+
+    @Override
+    public void validate(Class<?> type) {
+        EntityUtils.checkHasNoArgConstructor(type);
+        validateEntity(type);
+    }
+
+    abstract void validateEntity(Class<?> type);
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/EntityValidatorImpl.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/EntityValidatorImpl.java
@@ -1,0 +1,17 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.util.EntityUtils;
+
+public class EntityValidatorImpl extends AbstractRequiredValidator {
+
+    @Override
+    public void validateEntity(Class<?> type) {
+        EntityUtils.checkIsEntity(type);
+    }
+
+    @Override
+    public boolean support(Operation operation) {
+        return supportedOperations.contains(operation);
+    }
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/IdValidatorImpl.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/IdValidatorImpl.java
@@ -1,0 +1,29 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required;
+
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ID;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.exception.EntityValidationException;
+import com.bobocode.svydovets.bibernate.util.EntityUtils;
+import java.util.Arrays;
+
+public class IdValidatorImpl extends AbstractRequiredValidator {
+
+    @Override
+    public void validateEntity(Class<?> type) {
+        checkHasId(type);
+    }
+
+    @Override
+    public boolean support(Operation operation) {
+        return supportedOperations.contains(operation);
+    }
+
+    private void checkHasId(Class<?> type) {
+        Arrays.stream(type.getDeclaredFields())
+                .filter(EntityUtils::isIdField)
+                .findAny()
+                .orElseThrow(
+                        () -> new EntityValidationException(String.format(CLASS_HAS_NO_ID, type.getName())));
+    }
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessor.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessor.java
@@ -1,0 +1,10 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required.processor;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+
+public interface RequiredAnnotationValidatorProcessor {
+
+    void validate(Class<?> type, Operation operation);
+
+    void validate(Class<?> type);
+}

--- a/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessorImpl.java
+++ b/src/main/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessorImpl.java
@@ -1,0 +1,39 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required.processor;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.validation.annotation.required.AbstractRequiredValidator;
+import com.bobocode.svydovets.bibernate.validation.annotation.required.EntityValidatorImpl;
+import com.bobocode.svydovets.bibernate.validation.annotation.required.IdValidatorImpl;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RequiredAnnotationValidatorProcessorImpl
+        implements RequiredAnnotationValidatorProcessor {
+
+    private static final Set<AbstractRequiredValidator> validators = new LinkedHashSet<>();
+
+    public RequiredAnnotationValidatorProcessorImpl() {
+        initValidators();
+    }
+
+    private void initValidators() {
+        validators.add(new EntityValidatorImpl());
+        validators.add(new IdValidatorImpl());
+    }
+
+    @Override
+    public void validate(Class<?> type, Operation operation) {
+        log.info("Validation {}", type.getName());
+        validators.stream()
+                .filter(validator -> validator.support(operation))
+                .forEach(validator -> validator.validate(type));
+    }
+
+    @Override
+    public void validate(Class<?> type) {
+        log.info("Validation {}", type.getName());
+        validators.forEach(validator -> validator.validate(type));
+    }
+}

--- a/src/test/java/com/bobocode/svydovets/bibernate/testdata/entity/EntityWithoutIdAnnotation.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/testdata/entity/EntityWithoutIdAnnotation.java
@@ -1,0 +1,13 @@
+package com.bobocode.svydovets.bibernate.testdata.entity;
+
+import com.bobocode.svydovets.bibernate.annotation.Entity;
+import com.bobocode.svydovets.bibernate.annotation.Table;
+
+@Table("")
+@Entity
+public class EntityWithoutIdAnnotation {
+
+    Integer id;
+
+    public EntityWithoutIdAnnotation() {}
+}

--- a/src/test/java/com/bobocode/svydovets/bibernate/util/EntityUtilsTest.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/util/EntityUtilsTest.java
@@ -1,42 +1,18 @@
 package com.bobocode.svydovets.bibernate.util;
 
-import static com.bobocode.svydovets.bibernate.util.Constants.CLASS_HAS_NO_ARG_CONSTRUCTOR;
-import static com.bobocode.svydovets.bibernate.util.Constants.CLASS_HAS_NO_ENTITY_ANNOTATION;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.bobocode.svydovets.bibernate.exception.EntityValidationException;
-import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutNonArgConstructor;
-import com.bobocode.svydovets.bibernate.testdata.entity.NonEntityClass;
 import com.bobocode.svydovets.bibernate.testdata.entity.Person;
 import com.bobocode.svydovets.bibernate.testdata.entity.User;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class EntityUtilsTest {
-    @Test
-    @DisplayName("Non-entity class validation")
-    void nonEntityClassValidation() {
-        assertThatExceptionOfType(EntityValidationException.class)
-                .isThrownBy(() -> EntityUtils.validateEntity(NonEntityClass.class))
-                .withMessage(String.format(CLASS_HAS_NO_ENTITY_ANNOTATION, NonEntityClass.class.getName()));
-    }
-
-    @Test
-    @DisplayName("Validate entity without no-arg constructor")
-    void validateEntityWithoutNoArgConstructor() {
-        assertThatExceptionOfType(EntityValidationException.class)
-                .isThrownBy(() -> EntityUtils.validateEntity(EntityWithoutNonArgConstructor.class))
-                .withMessage(
-                        String.format(
-                                CLASS_HAS_NO_ARG_CONSTRUCTOR, EntityWithoutNonArgConstructor.class.getName()));
-    }
 
     @ParameterizedTest
     @MethodSource("entityWithFieldNamesSource")

--- a/src/test/java/com/bobocode/svydovets/bibernate/util/ObjectCloneUtilsTest.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/util/ObjectCloneUtilsTest.java
@@ -1,6 +1,6 @@
 package com.bobocode.svydovets.bibernate.util;
 
-import static com.bobocode.svydovets.bibernate.util.Constants.CAN_NOT_CREATE_A_SNAPSHOT_OF_ENTITY;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CAN_NOT_CREATE_A_SNAPSHOT_OF_ENTITY;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/EntityValidatorImplTest.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/EntityValidatorImplTest.java
@@ -1,0 +1,35 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required;
+
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ARG_CONSTRUCTOR;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ENTITY_ANNOTATION;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.bobocode.svydovets.bibernate.exception.EntityValidationException;
+import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutNonArgConstructor;
+import com.bobocode.svydovets.bibernate.testdata.entity.NonEntityClass;
+import com.bobocode.svydovets.bibernate.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EntityValidatorImplTest {
+
+    private final Validator entityValidator = new EntityValidatorImpl();
+
+    @Test
+    @DisplayName("Non-entity class validation using EntityValidatorImpl")
+    void nonEntityClassValidation() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> entityValidator.validate(NonEntityClass.class))
+                .withMessage(String.format(CLASS_HAS_NO_ENTITY_ANNOTATION, NonEntityClass.class.getName()));
+    }
+
+    @Test
+    @DisplayName("Validate entity without no-arg constructor using EntityValidatorImpl")
+    void validateEntityWithoutNoArgConstructor() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> entityValidator.validate(EntityWithoutNonArgConstructor.class))
+                .withMessage(
+                        String.format(
+                                CLASS_HAS_NO_ARG_CONSTRUCTOR, EntityWithoutNonArgConstructor.class.getName()));
+    }
+}

--- a/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/IdValidatorImplTest.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/IdValidatorImplTest.java
@@ -1,0 +1,35 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required;
+
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ARG_CONSTRUCTOR;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ID;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.bobocode.svydovets.bibernate.exception.EntityValidationException;
+import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutIdAnnotation;
+import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutNonArgConstructor;
+import com.bobocode.svydovets.bibernate.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IdValidatorImplTest {
+
+    private final Validator idValidator = new IdValidatorImpl();
+
+    @Test
+    @DisplayName("Validate entity without @Id")
+    void validateEntityWithoutIdAnnotation() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> idValidator.validate(EntityWithoutIdAnnotation.class))
+                .withMessage(String.format(CLASS_HAS_NO_ID, EntityWithoutIdAnnotation.class.getName()));
+    }
+
+    @Test
+    @DisplayName("Validate entity without no-arg constructor")
+    void validateEntityWithoutNoArgConstructor() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> idValidator.validate(EntityWithoutNonArgConstructor.class))
+                .withMessage(
+                        String.format(
+                                CLASS_HAS_NO_ARG_CONSTRUCTOR, EntityWithoutNonArgConstructor.class.getName()));
+    }
+}

--- a/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessorImplTest.java
+++ b/src/test/java/com/bobocode/svydovets/bibernate/validation/annotation/required/processor/RequiredAnnotationValidatorProcessorImplTest.java
@@ -1,0 +1,57 @@
+package com.bobocode.svydovets.bibernate.validation.annotation.required.processor;
+
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ARG_CONSTRUCTOR;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ENTITY_ANNOTATION;
+import static com.bobocode.svydovets.bibernate.constant.ErrorMessage.CLASS_HAS_NO_ID;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.bobocode.svydovets.bibernate.constant.Operation;
+import com.bobocode.svydovets.bibernate.exception.EntityValidationException;
+import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutIdAnnotation;
+import com.bobocode.svydovets.bibernate.testdata.entity.EntityWithoutNonArgConstructor;
+import com.bobocode.svydovets.bibernate.testdata.entity.NonEntityClass;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RequiredAnnotationValidatorProcessorImplTest {
+
+    private final RequiredAnnotationValidatorProcessor validatorProcessor =
+            new RequiredAnnotationValidatorProcessorImpl();
+
+    @Test
+    @DisplayName("Non-entity class validation")
+    void nonEntityClassValidation() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> validatorProcessor.validate(NonEntityClass.class, Operation.SELECT))
+                .withMessage(String.format(CLASS_HAS_NO_ENTITY_ANNOTATION, NonEntityClass.class.getName()));
+    }
+
+    @Test
+    @DisplayName("Non-entity class validation using all required annotation validators")
+    void nonEntityClassValidationUsingAllRequiredValidators() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(() -> validatorProcessor.validate(NonEntityClass.class))
+                .withMessage(String.format(CLASS_HAS_NO_ENTITY_ANNOTATION, NonEntityClass.class.getName()));
+    }
+
+    @Test
+    @DisplayName("Validate entity without no-arg constructor")
+    void validateEntityWithoutNoArgConstructor() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(
+                        () ->
+                                validatorProcessor.validate(EntityWithoutNonArgConstructor.class, Operation.SELECT))
+                .withMessage(
+                        String.format(
+                                CLASS_HAS_NO_ARG_CONSTRUCTOR, EntityWithoutNonArgConstructor.class.getName()));
+    }
+
+    @Test
+    @DisplayName("Validate entity without @Id")
+    void validateEntityWithoutIdAnnotation() {
+        assertThatExceptionOfType(EntityValidationException.class)
+                .isThrownBy(
+                        () -> validatorProcessor.validate(EntityWithoutIdAnnotation.class, Operation.SELECT))
+                .withMessage(String.format(CLASS_HAS_NO_ID, EntityWithoutIdAnnotation.class.getName()));
+    }
+}


### PR DESCRIPTION
Task:
https://trello.com/c/VrYhIiNs

Description:
Added Validator interface that can be used depending on the validation type or we can use all validors creating for that new ValidorProcessors
This is flexible because  if we will need to use all validators for example in the future if we will add constraint or property validators and we want to validate all annotations, properties, constraints in one place in the code we can create ValidaorProcessor for that

Now there is RequiredAnnotationValidatorProcessor that handles all required annotation for the entity
This class contains all Validators and validate step by step

If need to add for example validation for required @Table annotation than just create TableValidatorImpl that implements Validator and RequiredAnnotationValidatorProcessor will do the job.

